### PR TITLE
Adding order and pagination options to user mailing list

### DIFF
--- a/src/colab_superarchives/fixtures/test_user.json
+++ b/src/colab_superarchives/fixtures/test_user.json
@@ -96,5 +96,15 @@
       },
       "model": "accounts.emailaddress",
       "pk": 1
+    },
+    {
+      "fields": {
+        "real_name": "Norris",
+        "user": 2,
+        "md5": "dbe5c51bd2094a39a86187ca14107288",
+        "address": "chucknorris@mail.com"
+      },
+      "model": "accounts.emailaddress",
+      "pk": 2
     }
 ]


### PR DESCRIPTION
Adding pagination options to user mailing lists and ordering the mailing lists alphabetically on 'ManageUserSubscriptionsView' view.

Same feature as colab/colab#177.

Signed-off-by: Gabriel Silva gabriel93.silva@gmail.com
Signed-off-by: Italo Paiva italosensei@hotmail.com
Signed-off-by: Matheus S. Pereira matheussilva.fga@gmail.com
