### PR TITLE
Identified private lists for subscription

### DIFF
--- a/src/colab_superarchives/fixtures/test_user.json
+++ b/src/colab_superarchives/fixtures/test_user.json
@@ -96,5 +96,15 @@
       },
       "model": "accounts.emailaddress",
       "pk": 1
+    },
+    {
+      "fields": {
+        "real_name": "Norris",
+        "user": 2,
+        "md5": "dbe5c51bd2094a39a86187ca14107288",
+        "address": "chucknorris@mail.com"
+      },
+      "model": "accounts.emailaddress",
+      "pk": 2
     }
 ]

--- a/src/colab_superarchives/views.py
+++ b/src/colab_superarchives/views.py
@@ -448,7 +448,8 @@ class ManageUserSubscriptionsView(UserProfileBaseMixin, DetailView):
                     checked = False
                 lists.append((
                     {'listname': mlist.get('listname'),
-                     'description': mlist.get('description')},
+                     'description': mlist.get('description'),
+                     'archive_private': mlist.get('archive_private')},
                     checked
                 ))
 

--- a/src/colab_superarchives/views.py
+++ b/src/colab_superarchives/views.py
@@ -441,6 +441,7 @@ class ManageUserSubscriptionsView(UserProfileBaseMixin, DetailView):
             lists = []
             lists_for_address = mailman.mailing_lists(address=email,
                                                       names_only=True)
+
             for mlist in all_lists:
                 if mlist.get('listname') in lists_for_address:
                     checked = True

--- a/tests/test_mailinglist_view.py
+++ b/tests/test_mailinglist_view.py
@@ -119,3 +119,15 @@ class MailingListViewTest(TestCase):
                          'privatelist')
         self.assertEqual(response.context['thread_list'][0].subject_token,
                          'Subject3')
+
+    @patch('colab_superarchives.views.mailman.all_lists',
+           return_value=[{'listname': 'privatelist', 'archive_private': 1}])
+    def test_identification_private_list_on_subscription(self, mock):
+        self.authenticate_user()
+        response = self.client.get(
+            '/archives/' + self.username + '/subscriptions'
+        )
+
+        expected_message = 'Private'
+        self.assertEqual(200, response.status_code)
+        self.assertIn(expected_message, response.content)


### PR DESCRIPTION
"Private" label is shown on "Manage User Group Lists" page to identify private mailing lists.

<img width="1280" alt="captura de tela 2016-05-12 as 17 04 01" src="https://cloud.githubusercontent.com/assets/3230876/15228970/08a9a80e-1865-11e6-8ad3-dffb86680efc.png">
